### PR TITLE
Report outputs

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust:
           - stable
-          - 1.53.0
+          - 1.56.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -55,7 +55,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust:
           - stable
-          - 1.53.0
+          - 1.56.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,43 +4,43 @@ version = 3
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b800c4403e8105d959595e1f88119e78bc12bc874c4336973658b648a746ba93"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
 dependencies = [
  "bstr",
  "doc-comment",
- "predicates 2.0.2",
+ "predicates 2.1.1",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bgzip"
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
 name = "bzip2"
@@ -129,9 +129,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -141,9 +144,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -156,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -188,10 +191,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "flate2"
-version = "1.0.19"
+name = "fastrand"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -215,48 +227,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa334a728fecaf0922f5735ede5f27c08fefc7c4e5b04c5efe02a3861b512f2e"
 
 [[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.8"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "indoc"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+checksum = "e7906a9fababaeacb774f72410e497a1d18de916322e33797bb2cd29baa23c9e"
 dependencies = [
  "unindent",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.1"
+name = "instant"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -268,6 +278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,9 +294,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "lzma-sys"
@@ -292,23 +311,22 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
 name = "nanoq"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -341,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "niffler"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a7f12f3a029d01c9018f80bf5335b0f39f26c1cc898d394e8b72db09ee7957"
+checksum = "68c7ffd42bdba05fc9fbfda31283d44c5c8a88fed1a191f68795dba23cc8204b"
 dependencies = [
  "bgzip",
  "bzip2",
@@ -351,6 +369,7 @@ dependencies = [
  "flate2",
  "thiserror",
  "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -361,24 +380,18 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "predicates"
@@ -395,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "2.0.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c143348f141cc87aab5b950021bac6145d0e5ae754b0591de23244cee42c9308"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "itertools",
@@ -406,18 +419,18 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd0fd014130206c9352efbdc92be592751b2b9274dff685348341082c6ea3d"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
- "treeline",
+ "termtree",
 ]
 
 [[package]]
@@ -446,76 +459,36 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -557,18 +530,18 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "serde"
-version = "1.0.121"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6159e3c76cab06f6bc466244d43b35e77e9500cd685da87620addadc2a4c40b1"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.121"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3fcab8778dc651bc65cfab2e4eb64996f3c912b74002fb379c94517e1f27c46"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -577,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
@@ -594,9 +567,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.23"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -605,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -618,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.59"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cb8b1b4ebf86a89ee88cbd201b022b94138c623644d035185c84d3f41b7e66"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -629,17 +602,23 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
@@ -652,18 +631,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -671,46 +650,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "treeline"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
-
-[[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "unindent"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
+checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
@@ -722,16 +695,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -756,4 +723,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "zstd"
+version = "0.7.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "3.1.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.5.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +318,8 @@ dependencies = [
  "needletail",
  "niffler",
  "predicates 1.0.8",
+ "serde",
+ "serde_json",
  "structopt",
  "tempfile",
  "thiserror",
@@ -536,10 +544,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
+name = "serde"
+version = "1.0.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6159e3c76cab06f6bc466244d43b35e77e9500cd685da87620addadc2a4c40b1"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3fcab8778dc651bc65cfab2e4eb64996f3c912b74002fb379c94517e1f27c46"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ needletail = "0.4.1"
 thiserror = "1.0"
 niffler = "2.3"
 float_eq = "0.6.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanoq"
-version = "0.8.6"
+version = "0.9.0"
 authors = ["esteinig <eike.steinig@unimelb.edu.au>", "ljmcoin <lachlan.coin@unimelb.edu.au>"]
 description = "Minimal but speedy quality control and summaries of nanopore reads"
 documentation = "https://github.com/esteinig/nanoq"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-ENV VERSION=0.8.6
+ENV VERSION=0.9.0
 ENV RELEASE=nanoq-${VERSION}-x86_64-unknown-linux-musl.tar.gz
 
 RUN apk update && apk add --no-cache wget

--- a/README.md
+++ b/README.md
@@ -97,18 +97,18 @@ nanoq -i test.fq -l 1000 -m 10000 -q 10 -w 15 > reads.fq
 
 ### Read report
 
-Read summaries without output can be obtained by directing to `/dev/null` or using the stats flag (`-s`):
+Read summaries are produced when using the stats flag (`-s`, report to `stdout`, no read output to `stdout`) or when specifying a report file (`-r`):
 
 ```bash
-nanoq -i test.fq > /dev/null
 nanoq -i test.fq -s
+nanoq -i test.fq -r report.txt > reads.fq
 ```
 
 For report types and configuration see the [output section](#output).
 
 ### Fast mode
 
-> :warning: When using fast mode `-f` read quality scores are not computed (`NaN`)
+> :warning: When using fast mode `-f` read quality scores are not computed (output of quality fields: `NaN`)
 
 Read qualities may be excluded from filters and statistics to speed up read iteration (`-f`).
 
@@ -127,7 +127,7 @@ nanoq -i test.fq -o reads.fq.gz
 Output compression can be specified manually with `-O` and `-c`.
 
 ```bash
-nanoq -i test.fq -O g -c 9 -o reads.fq.cmp
+nanoq -i test.fq -O g -c 9 -o reads.fq.gz
 ```
 
 ### Online runs
@@ -158,10 +158,10 @@ FLAGS:
     -f, --fast       Ignore quality values if present
     -h, --help       Prints help information
     -H, --header     Header for summary output
-    -j, --json       Summary report in JSON
-    -s, --stats      Summary statistics report
+    -j, --json       Summary report in JSON format
+    -s, --stats      Summary report only [stdout]
     -V, --version    Prints version information
-    -v, --verbose    Verbose output statistics [multiple up to -vvv]
+    -v, --verbose    Verbose output statistics [multiple, up to -vvv]
 
 OPTIONS:
     -c, --compress-level <1-9>     Compression level to use if compressing output [default: 6]
@@ -178,23 +178,17 @@ OPTIONS:
 
 ### Output
 
-A basic read summary is output to `stderr`:
-
-```bash
-nanoq -i test.fq > reads.fq 2> report.txt
-```
-
-When using the `--stats/-s` flag the summary is output to `stdout`: 
-
-```bash
-nanoq -i test.fq -s > report.txt
-```
-
-Summary reports can also be output to a file explicitly (instead of `stderr/stdout`) using the `--report/-r` option:
+Summary reports are output to file explicitly using `--report/-r`:
 
 ```bash
 nanoq -i test.fq -r report.txt > reads.fq
 nanoq -i test.fq -r report.txt -s
+```
+
+When using the `--stats/-s` flag read output is suppressed and summary is directed to `stdout`: 
+
+```bash
+nanoq -i test.fq -s > report.txt
 ```
 
 Report format is minimal by default:
@@ -221,8 +215,12 @@ nanoq -i test.fq -s -H
 
 Extended summaries analogous to `NanoStat` can be obtained using multiple `-v` flags (up to `-vvv`), including the top (`-t`) read lengths and qualities:
 
+* `-v` - verbose read summary (top block as below)
+* `-vv` - like `-v` with read length and/or quality thresholds 
+* `-vvv` - like `-vv` with top ranking read lengths and/or qualities
+
 ```bash
-nanoq -i test.fq -f -s -t 5 -vv
+nanoq -i test.fq -f -s -t 5 -vvv
 ```
 
 ```
@@ -263,7 +261,7 @@ Top ranking read lengths (bp)
 5. 35630
 ```
 
-JSON formatted extended output (equivalent to `-vvv`) can be output to file or `stderr/stdout` using the `--json/-j` flag:
+JSON formatted extended output (equivalent to `-vvv`) can be output to `--report` (`-r`) or `stdout` (`-s`) using the `--json/-j` flag:
 
 ```bash
 nanoq -i test.fq --json -f -r report.json > reads.fq
@@ -310,9 +308,9 @@ nanoq -i test.fq --json -f -s > report.json
 }
 ```
 
+Note that in this example no read qualities are computed; quality thresholds are therefore all zero.
 
 ## Benchmarks
-
 
 Benchmarks evaluate processing speed and memory consumption of a basic read length filter and summary statistics on the even [Zymo mock community](https://github.com/LomanLab/mockcommunity) (`GridION`) with comparisons to [`rust-bio-tools`](https://github.com/rust-bio/rust-bio-tools), [`seqtk fqchk`](https://github.com/lh3/seqtk), [`seqkit stats`](https://github.com/shenwei356/seqkit), [`NanoFilt`](https://github.com/wdecoster/nanofilt), [`NanoStat`](https://github.com/wdecoster/nanostat) and [`Filtlong`](https://github.com/rrwick/Filtlong). Time to completion and maximum memory consumption were measured using `/usr/bin/time -f "%e %M"`, speedup is relative to the slowest command in the set. We note that summary statistics from `rust-bio-tools` and `seqkit stats` do not compute read quality scores and are therefore comparable to `nanoq-fast`.
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![build](https://github.com/esteinig/nanoq/actions/workflows/rust-ci.yaml/badge.svg?branch=master)](https://github.com/esteinig/nanoq/actions/workflows/rust-ci.yaml)
 [![codecov](https://codecov.io/gh/esteinig/nanoq/branch/master/graph/badge.svg?token=1X04YD8YOE)](https://codecov.io/gh/esteinig/nanoq)
-![](https://img.shields.io/badge/version-0.8.6-black.svg)
+![](https://img.shields.io/badge/version-0.9.0-black.svg)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.02991/status.svg)](https://doi.org/10.21105/joss.02991)
 
 Ultra-fast quality control and summary reports for nanopore reads
 
 ## Overview
 
-**`v0.8.6`**
+**`v0.9.0`**
 
 - [Purpose](#purpose)
 - [Install](#install)
@@ -61,7 +61,7 @@ cargo install nanoq
 Explicit version (for some reason defaults to old version)
 
 ```
-conda install -c conda-forge -c bioconda nanoq=0.8.6
+conda install -c conda-forge -c bioconda nanoq=0.9.0
 ```
 
 #### `Binaries`
@@ -69,7 +69,7 @@ conda install -c conda-forge -c bioconda nanoq=0.8.6
 Precompiled binaries for Linux and MacOS are attached to the latest release.
 
 ```
-VERSION=0.8.6
+VERSION=0.9.0
 RELEASE=nanoq-${VERSION}-x86_64-unknown-linux-musl.tar.gz
 
 wget https://github.com/esteinig/nanoq/releases/download/${VERSION}/${RELEASE}
@@ -147,7 +147,7 @@ done
 ### Parameters
 
 ```
-nanoq 0.8.6
+nanoq 0.9.0
 
 Read filters and summary reports for nanopore data
 
@@ -158,6 +158,7 @@ FLAGS:
     -f, --fast       Ignore quality values if present
     -h, --help       Prints help information
     -H, --header     Header for summary output
+    -j, --json       Summary report in JSON
     -s, --stats      Summary statistics report
     -V, --version    Prints version information
     -v, --verbose    Verbose output statistics [multiple up to -vvv]
@@ -171,12 +172,32 @@ OPTIONS:
     -q, --min-qual <FLOAT>         Minimum average read quality filter (Q) [default: 0]
     -o, --output <output>          Output filepath, stdout if not present
     -O, --output-type <u|b|g|l>    u: uncompressed; b: Bzip2; g: Gzip; l: Lzma
+    -r, --report <report>          Summary read statistics report output file
     -t, --top <INT>                Number of top reads in verbose summary [default: 5]
 ```
 
 ### Output
 
-A basic read summary is output to `stderr`: 
+A basic read summary is output to `stderr`:
+
+```bash
+nanoq -i test.fq > reads.fq 2> report.txt
+```
+
+When using the `--stats/-s` flag the summary is output to `stdout`: 
+
+```bash
+nanoq -i test.fq -s > report.txt
+```
+
+Summary reports can also be output to a file explicitly (instead of `stderr/stdout`) using the `--report/-r` option:
+
+```bash
+nanoq -i test.fq -r report.txt > reads.fq
+nanoq -i test.fq -r report.txt -s
+```
+
+Report format is minimal by default:
 
 ```bash
 100000 400398234 5154 44888 5 4003 3256 8.90 9.49
@@ -201,7 +222,7 @@ nanoq -i test.fq -s -H
 Extended summaries analogous to `NanoStat` can be obtained using multiple `-v` flags (up to `-vvv`), including the top (`-t`) read lengths and qualities:
 
 ```bash
-nanoq -i test.fq -f -s -vv
+nanoq -i test.fq -f -s -t 5 -vv
 ```
 
 ```
@@ -241,6 +262,54 @@ Top ranking read lengths (bp)
 4. 36543       
 5. 35630
 ```
+
+JSON formatted extended output (equivalent to `-vvv`) can be output to file or `stderr/stdout` using the `--json/-j` flag:
+
+```bash
+nanoq -i test.fq --json -f -r report.json > reads.fq
+nanoq -i test.fq --json -f -s > report.json
+```
+
+```json
+{
+  "reads": 100000,
+  "bases": 400398234,
+  "n50": 5154,
+  "longest": 44888,
+  "shortest": 5,
+  "mean_length": 4003,
+  "median_length": 3256,
+  "mean_quality": null,
+  "median_quality": null,
+  "length_thresholds": {
+    "200": 99104,
+    "500": 96406,
+    "1000": 90837,
+    "2000": 73579,
+    "5000": 25515,
+    "10000": 4987,
+    "30000": 47,
+    "50000": 0,
+    "100000": 0,
+    "1000000": 0
+  },
+  "quality_thresholds": {
+    "5": 0,
+    "7": 0,
+    "10": 0,
+    "12": 0,
+    "15": 0,
+    "20": 0,
+    "25": 0,
+    "30": 0
+  },
+  "top_lengths": [
+    44888, 40044, 37441, 36543, 35630
+  ],
+  "top_qualities": []
+}
+```
+
 
 ## Benchmarks
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,15 +46,15 @@ pub struct Cli {
     #[structopt(short, long, value_name = "INT", default_value = "5")]
     pub top: usize,
 
-    /// Summary read statistics report.
+    /// Summary report only [stdout].
     #[structopt(short, long)]
     pub stats: bool,
 
-    /// Summary read statistics report output file.
+    /// Summary report output file.
     #[structopt(short, long)]
     pub report: Option<PathBuf>,
 
-    /// Summary report in JSON
+    /// Summary report in JSON format.
     #[structopt(short, long)]
     pub json: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,9 +54,9 @@ pub struct Cli {
     #[structopt(short, long)]
     pub report: Option<PathBuf>,
 
-     /// Summary report in JSON
-     #[structopt(short, long)]
-     pub json: bool,
+    /// Summary report in JSON
+    #[structopt(short, long)]
+    pub json: bool,
 
     /// Ignore quality values if present.
     #[structopt(short, long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,9 +46,13 @@ pub struct Cli {
     #[structopt(short, long, value_name = "INT", default_value = "5")]
     pub top: usize,
 
-    /// Summary statistics report.
+    /// Summary read statistics report.
     #[structopt(short, long)]
     pub stats: bool,
+
+    /// Summary read statistics report output file.
+    #[structopt(short, long)]
+    pub report: Option<PathBuf>,
 
     /// Ignore quality values if present.
     #[structopt(short, long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,10 @@ pub struct Cli {
     #[structopt(short, long)]
     pub report: Option<PathBuf>,
 
+     /// Summary report in JSON
+     #[structopt(short, long)]
+     pub json: bool,
+
     /// Ignore quality values if present.
     #[structopt(short, long)]
     pub fast: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,14 @@ fn main() -> Result<()> {
     let mut read_set = ReadSet::new(read_lengths, read_qualities);
 
     read_set
-        .summary(&cli.verbose, cli.top, cli.header, cli.stats, cli.json, cli.report)
+        .summary(
+            &cli.verbose,
+            cli.top,
+            cli.header,
+            cli.stats,
+            cli.json,
+            cli.report,
+        )
         .context("unable to get summary")?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
     let mut read_set = ReadSet::new(read_lengths, read_qualities);
 
     read_set
-        .summary(&cli.verbose, cli.top, cli.header)
+        .summary(&cli.verbose, cli.top, cli.header, cli.stats)
         .context("unable to get summary")?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
     let mut read_set = ReadSet::new(read_lengths, read_qualities);
 
     read_set
-        .summary(&cli.verbose, cli.top, cli.header, cli.stats)
+        .summary(&cli.verbose, cli.top, cli.header, cli.stats, cli.report)
         .context("unable to get summary")?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
     let mut read_set = ReadSet::new(read_lengths, read_qualities);
 
     read_set
-        .summary(&cli.verbose, cli.top, cli.header, cli.stats, cli.report)
+        .summary(&cli.verbose, cli.top, cli.header, cli.stats, cli.json, cli.report)
         .context("unable to get summary")?;
 
     Ok(())

--- a/src/needlecast.rs
+++ b/src/needlecast.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::{sink, stdout};
 use std::io::{BufWriter, Write};
 
+
 use crate::cli::Cli;
 use crate::utils::CompressionExt;
 
@@ -263,8 +264,11 @@ mod tests {
         let mut caster = NeedleCast::new(&cli);
         let (read_lengths, read_quals) = caster.filter(0, 3, 0.0, 0.0).unwrap();
 
-        assert_eq!(read_lengths, vec![]);
-        assert_eq!(read_quals, vec![]);
+        let expected_length: Vec<u32> = vec![];
+        let expected_quality: Vec<f32> = vec![];
+
+        assert_eq!(read_lengths, expected_length);
+        assert_eq!(read_quals, expected_quality);
     }
 
     #[test]
@@ -275,8 +279,10 @@ mod tests {
         let mut caster = NeedleCast::new(&cli);
         let (read_lengths, read_quals) = caster.filter_length(0, 0).unwrap();
 
+        let expected_quality: Vec<f32> = vec![];
+        
         assert_eq!(read_lengths, vec![4, 8]);
-        assert_eq!(read_quals, vec![]);
+        assert_eq!(read_quals, expected_quality);
     }
 
     #[test]
@@ -288,15 +294,18 @@ mod tests {
         let mut caster = NeedleCast::new(&cli);
         let (read_lengths, read_quals) = caster.filter_length(0, 3).unwrap();
 
-        assert_eq!(read_lengths, vec![]);
-        assert_eq!(read_quals, vec![]);
+        let expected_length: Vec<u32> = vec![];
+        let expected_quality: Vec<f32> = vec![];
+
+        assert_eq!(read_lengths, expected_length);
+        assert_eq!(read_quals, expected_quality);
 
         // NeedleCast struct has to be initiated again to reset filter length parameters
         let mut caster = NeedleCast::new(&cli);
         let (read_lengths, read_quals) = caster.filter_length(0, 5).unwrap();
 
         assert_eq!(read_lengths, vec![4]);
-        assert_eq!(read_quals, vec![]);
+        assert_eq!(read_quals, expected_quality);
     }
 
     #[test]
@@ -307,16 +316,18 @@ mod tests {
 
         let mut caster = NeedleCast::new(&cli);
         let (read_lengths, read_quals) = caster.filter_length(5, 0).unwrap();
+        
+        let expected_quality: Vec<f32> = vec![];
 
         assert_eq!(read_lengths, vec![8]);
-        assert_eq!(read_quals, vec![]);
+        assert_eq!(read_quals, expected_quality);
 
         // NeedleCast struct has to be initiated again to reset filter length parameters
         let mut caster = NeedleCast::new(&cli);
         let (read_lengths, read_quals) = caster.filter_length(4, 0).unwrap();
 
         assert_eq!(read_lengths, vec![4, 8]);
-        assert_eq!(read_quals, vec![]);
+        assert_eq!(read_quals, expected_quality);
     }
 
     #[test]
@@ -327,8 +338,10 @@ mod tests {
         let mut caster = NeedleCast::new(&cli);
         let (read_lengths, read_quals) = caster.filter(0, 0, 0.0, 0.0).unwrap();
 
+        let expected_quality: Vec<f32> = vec![];
+
         assert_eq!(read_lengths, vec![4]);
-        assert_eq!(read_quals, vec![]);
+        assert_eq!(read_quals, expected_quality);
     }
 
     #[test]
@@ -339,8 +352,10 @@ mod tests {
         let mut caster = NeedleCast::new(&cli);
         let (read_lengths, read_quals) = caster.filter_length(0, 0).unwrap();
 
+        let expected_quality: Vec<f32> = vec![];
+        
         assert_eq!(read_lengths, vec![4]);
-        assert_eq!(read_quals, vec![]);
+        assert_eq!(read_quals, expected_quality);
     }
 
     #[test]

--- a/src/needlecast.rs
+++ b/src/needlecast.rs
@@ -128,7 +128,7 @@ impl NeedleCast {
                         .expect("failed to write fastq record");
                 }
             } else {
-                // FASTA filter
+                // FASTA
                 if seqlen >= min_length && seqlen <= max_length {
                     read_lengths.push(seqlen);
                     rec.write(&mut self.writer, None)

--- a/src/needlecast.rs
+++ b/src/needlecast.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use std::io::{sink, stdout};
 use std::io::{BufWriter, Write};
 
-
 use crate::cli::Cli;
 use crate::utils::CompressionExt;
 
@@ -280,7 +279,7 @@ mod tests {
         let (read_lengths, read_quals) = caster.filter_length(0, 0).unwrap();
 
         let expected_quality: Vec<f32> = vec![];
-        
+
         assert_eq!(read_lengths, vec![4, 8]);
         assert_eq!(read_quals, expected_quality);
     }
@@ -316,7 +315,7 @@ mod tests {
 
         let mut caster = NeedleCast::new(&cli);
         let (read_lengths, read_quals) = caster.filter_length(5, 0).unwrap();
-        
+
         let expected_quality: Vec<f32> = vec![];
 
         assert_eq!(read_lengths, vec![8]);
@@ -353,7 +352,7 @@ mod tests {
         let (read_lengths, read_quals) = caster.filter_length(0, 0).unwrap();
 
         let expected_quality: Vec<f32> = vec![];
-        
+
         assert_eq!(read_lengths, vec![4]);
         assert_eq!(read_quals, expected_quality);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -358,14 +358,14 @@ impl ReadSet {
             },
             None => {
                 // If no report file is specified, output the report to
-                // stdout (--stats) or stderr (no --stats)
+                // stdout with the --stats flag
                 let output_string = match json {
                     true => serde_json::to_string_pretty(&output_data)?,
                     false => output_string,
                 };
                 match stats {
                     true => println!("{}", output_string),
-                    false => eprintln!("{}", output_string),
+                    false => {} // do not output when not using --stats or --report
                 }
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -962,5 +962,4 @@ mod tests {
             .summary(&0, 1, true, true, true, None)
             .unwrap();
     }
-    
 }


### PR DESCRIPTION
*  `--stats/-s` now outputs the summary to `stdout` --> #31

```bash
nanoq -i test.fq -s > report.txt
```

*  `--report/-r` always writes the report to a file

```bash
nanoq -i test.fq -s -r report.txt
```

* report is **not** output to `stderr` when filtering (or ever); use explicit report file option

```bash
nanoq -i test.fq -r report.txt > reads.fq
```

* `--json/-j` outputs the report in JSON (equivalent to `-vvv`) --> #30